### PR TITLE
Feature/mini data release

### DIFF
--- a/HowToGetNumbersAndSections.md
+++ b/HowToGetNumbersAndSections.md
@@ -19,4 +19,29 @@ Then execute this (replacing the value for what goes after mktime) and copy the 
 curl 'https://wwwdev.ebi.ac.uk/gxa/sc/json/experiments' | jq -r '.aaData | .[] | select(.lastUpdate | strptime("%d-%m-%Y") | mktime > 1552867200) | [.experimentAccession, .experimentDescription] | @csv' | awk -v FS="," '{ printf "- [%s](https://www.ebi.ac.uk/gxa/sc/experiments/%s)\n", $2, $1}' | sed s/\"//g
 ```
 
+Top 15 species by studies count overall in atlas (including single cell expression atlas)
+
+```
+IFS="
+"
+
+all_species=`curl -s https://wwwdev.ebi.ac.uk/gxa/json/experiments | jq '.aaData | .[].species' | sort -u`
+
+for species in $all_species; do
+	 differential_studies=`curl -s https://wwwdev.ebi.ac.uk/gxa/json/experiments | jq '.aaData | map(select(.species | contains('"$species"'))) | map(select(.experimentType | test("(MICROARRAY)|(DIFFERENTIAL)"; "i"))) | length'`
+	 baseline_studies=`curl -s https://wwwdev.ebi.ac.uk/gxa/json/experiments | jq '.aaData | map(select(.species | contains('"$species"'))) | map(select(.experimentType | test("(BASELINE)"; "i"))) | length'`
+	 singlecell_studies=`curl -s https://wwwdev.ebi.ac.uk/gxa/sc/json/experiments | jq '.aaData | map(select(.species | contains('"$species"'))) | map(select(.experimentType | test("(BASELINE)"; "i"))) | length'`
+	 echo -e $species"\t"$differential_studies"\t"$baseline_studies"\t"$singlecell_studies	>> species_stats.txt
+done
+
+### top 15
+echo -e "Species\tNumber_of_differential_studies\tNumber_of_baseline_studies\tNumber_of_singlecell_studies" > top_15_species.txt	
+sort -r -nk3 species_stats.txt  | head -n15 >> top_15_species.txt
+
+## include `Others` species as cumulative count as last row
+differential_others=`sort -r -nk3 species_stats.txt | awk 'NR>15' | cut -f2 | awk '{total += $0} END{print ""total}'`
+baseline_others=`sort -r -nk3 species_stats.txt | awk 'NR>15' | cut -f3 | awk '{total += $0} END{print ""total}'`
+sc_others=`sort -r -nk3 species_stats.txt | awk 'NR>15' | cut -f4 | awk '{total += $0} END{print ""total}'`
+echo -e "Others\t$differential_others\t$baseline_others\t$sc_others" >> top_15_species.txt
+```
 On a mac you could pipe the above command to `pbcopy` and that will leave everything in your clipboard.

--- a/release-notes/gxa/_posts/2019-09-17-32.md
+++ b/release-notes/gxa/_posts/2019-09-17-32.md
@@ -1,0 +1,32 @@
+#### Data statistics
+
+- Ensembl **96** / Ensembl Genomes **43** / WormBase ParaSite **12** gene annotations and
+  array design probe set mappings.   
+- This release contains **3,588** datasets (**114,907** assays), in particular:            
+  - **837** RNA-seq and **21** proteomics datasets, of which **179** report
+    [baseline](https://www.ebi.ac.uk/gxa/baseline/experiments) gene expression, across a total of **43** different
+    organisms;           
+  - **805** datasets reporting expression in [plants](https://www.ebi.ac.uk/gxa/plant/experiments);               
+  - **3,409** datasets studying samples in **9,934**
+    [differential](https://www.ebi.ac.uk/gxa/help/index.html#differential-expression) comparisons across **47**
+    different organisms.
+  - **62** overall species count
+
+
+#### New experiments
+
+- [RNA-Seq of zebrafish embryos with wdr37 missense variant compared to wild type](https://www.ebi.ac.uk/gxa/experiments/E-MTAB-8029)
+- [RNA-Seq of the liver of hypercholesterolemic mice treated by either ticagrelor, clopidogrel, or control](https://www.ebi.ac.uk/gxa/experiments/E-MTAB-8049)
+- [Transcriptome analysis of human brain microvascular endothelial cells response to interactive DIII domain of protein E of WNV and interactive DIII domain of protein E of TBEV using RNA-seq](https://www.ebi.ac.uk/gxa/experiments/E-MTAB-8052)
+- [RNA-Seq of rat myocardial slices cultured with biomimetic electromechanical stimulation](https://www.ebi.ac.uk/gxa/experiments/E-MTAB-7842)
+- [RNA-Seq of chicken breast samples treated with chronic heat stress](https://www.ebi.ac.uk/gxa/experiments/E-MTAB-7479)
+- [RNA-seq of neuronal SOX2-ablated murine suprachiasmatic nuclei against wild-type littermate controls](https://www.ebi.ac.uk/gxa/experiments/E-MTAB-7496)
+- [RNA-seq in GR18 cell line to identify genes regulated by the Glucocorticoid Receptor (24h treatment)](https://www.ebi.ac.uk/gxa/experiments/E-MTAB-7745)
+
+- New Baseline experiments      
+  - [RNA-sequencing of 465 lymphoblastoid cell lines from the 1000 Genomes](https://www.ebi.ac.uk/gxa/experiments/E-GEUV-1)
+  - [RNA-seq analysis of six cell line models for haematopoiesis: Project 1 of Open Targets - Epigenomes of Cell Lines](https://www.ebi.ac.uk/gxa/experiments/E-MTAB-4101)
+  - [Human RNA-seq time-series of the development of seven major organs](https://www.ebi.ac.uk/gxa/experiments/E-MTAB-6814)
+  - [Rat RNA-seq time-series of the development of seven major organs](https://www.ebi.ac.uk/gxa/experiments/E-MTAB-6811)
+
+


### PR DESCRIPTION
- GXA atlas release notes for mini data release happened last month. 
- All the stats are extracted from web API pointing to `https://www.ebi.ac.uk/gxa/json/experiments` instead of `https://wwwdev.ebi.ac.uk/gxa/json/experiments` as we have loaded several studies in dev since actual mini data release. Hence used former url to make numbers look consistent in prod. 
- Top 15 species code snippet added for future generation atlas species tables of species count for paper/conferences. 