### PR TITLE
GXA data release stats and release notes include covid studies

### DIFF
--- a/release-notes/gxa/_posts/2020-05-05-35.md
+++ b/release-notes/gxa/_posts/2020-05-05-35.md
@@ -15,12 +15,30 @@
 
 #### New experiments
 
-- New experiments relevant to the current *Coronavirus (COVID-19)* outbreak research.
+- New *23* experiments relevant to the current *Coronavirus (COVID-19)* outbreak research.
   - [Transcriptional response of human lung epithelial cells to SARS-CoV-2 infection.](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-147507)
+  - [Transcription profiling by array of human bronchial epithelial cells after infection with SARS-CoV and DOHV](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-17400)
+  - [SHAE004: SARS-CoV, SARS-dORF6 and SARS-BatSRBD infection of HAE cultures.](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-47962)
   - [Host responses contributing to the attenuation of severe acute respiratory syndrome coronaviruses missing E protein domains](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-59185)
+  - [Transcription profiling of human bronchial epithelial cell line Calu-3 2B4 infected with Human Coronavirus MERS-CoV-London](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-56677)
   - [SARS infection of C57BL6, TIMP1 and Serpine1 knock-out mice](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-51386)
   - [Human airway epithelial responses to rhinovirus infection and cigarette smoke extract alone and in combination](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-27973)
   - [Infection of wild type and CXCR3 knockout C57BL6/J mice with SARS MA15](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-50878)
+  - [Mouse lung tissue transcriptome response to a mouse-adapted strain of SARS-CoV in wild type C57BL6/NJ mice and TLR3-/- mice](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-68820)
+  - [SM001: SARS CoV MA15 infection of C57Bl/6 mouse model – Data from 4 viral doses at 1, 2, 4 and 7 days post infection.](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-33266)
+  - [Time course analysis of icSARS CoV Urbani or icSARS deltaORF6 infected Calu-3 2B4 bronchial epithelial cells](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-33267)
+  - [Transcriptional profile of PBMCs in patients with acute RSV or Influenza infection](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-34205)
+  - [Transcriptomic analysis of host response to mouse-adapted SARS virus in wild type, STAT1 -/-, and IFNAR1 -/- mouse genetic backgrounds](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-36016)
+  - [Expression data from primary human keratinocytes exposed to cytokines in vitro (IL-4, IL-13, IL-17A, IFN-alpha, IFN-gamma, TNF)](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-36287)
+  - [SCL006,icSARS CoV Urbani or icSARS Bat SRBD (spike receptor binding domain from the wild type strain Urbani to allow for infection of human and non-human primate cells) infections of the 2B4 clonal derivative of Calu-3 cells - Time course](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-37827)
+  - [SM019 - Infection with SARS MA15 of C57BL/6J mice and Tnfrsf1b knockout mice](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-40824)
+  - [SM020 - Infection with SARS MA15 of C57BL/6J mice and KEPI (ppp1r14c) knockouts](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-40827)
+  - [SM015 - Infection with SARS MA15 of C57BL/6J mice and Tnfrsf1a/1b knockouts](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-40840)
+  - [Transcription profiling of human bronchial epithelial cell line Calu-3 2B4 infected with Human Coronavirus EMC 2012](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-45042)
+  - [SM012 - SARS MA15 wild type, and SARS deltaORF6 mutant virus infections of C57BL6 mice - A time course](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-49262)
+  - [SM014 - SARS MA15 wild type, and SARS nsp16 mutant virus infections of C57BL6 mice - A time course](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-49263)
+  - [SM009 - SARS infection of C57BL6, and PLAT knock-out mice.](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-51387)
+  - [Genomic profiling of collaborative cross founder mouse strains infected with respiratory viruses to discover novel transcripts and infection-related strain-specific gene and isoform expression](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-52405)
 
 - New Differential experiments      
   - [Transcriptome analysis of the effect of the hsl2 mutation in root tips](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-116517)

--- a/release-notes/gxa/_posts/2020-05-05-35.md
+++ b/release-notes/gxa/_posts/2020-05-05-35.md
@@ -15,7 +15,7 @@
 
 #### New experiments
 
-- New Coronavirus disease (COVID) experiments
+- New experiments relevant to the current *Coronavirus (COVID-19)* outbreak research.
   - [Transcriptional response of human lung epithelial cells to SARS-CoV-2 infection.](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-147507)
   - [Host responses contributing to the attenuation of severe acute respiratory syndrome coronaviruses missing E protein domains](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-59185)
   - [SARS infection of C57BL6, TIMP1 and Serpine1 knock-out mice](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-51386)
@@ -45,6 +45,5 @@
   - [Grapevine field experiments reveal the contribution of genotype, the influence of environment and the effect of their interaction (G3E) on the berry transcriptome [RNA-seq]](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-97960)
   - [mRNA-Seq of head tissue from Drosophila melanogaster](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-57337)
   - [Transcription profiling by high throughput sequencing of maize B73, Mo17 and the SX19 inbred mapping population](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-97960)
-
 
 

--- a/release-notes/gxa/_posts/2020-05-05-35.md
+++ b/release-notes/gxa/_posts/2020-05-05-35.md
@@ -15,7 +15,7 @@
 
 #### New experiments
 
-- New *23* experiments relevant to the current *Coronavirus (COVID-19)* outbreak research.
+- *23* New experiments relevant to the current *Coronavirus (COVID-19)* outbreak research.
   - [Transcriptional response of human lung epithelial cells to SARS-CoV-2 infection.](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-147507)
   - [Transcription profiling by array of human bronchial epithelial cells after infection with SARS-CoV and DOHV](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-17400)
   - [SHAE004: SARS-CoV, SARS-dORF6 and SARS-BatSRBD infection of HAE cultures.](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-47962)

--- a/release-notes/gxa/_posts/2020-05-05-35.md
+++ b/release-notes/gxa/_posts/2020-05-05-35.md
@@ -15,7 +15,7 @@
 
 #### New experiments
 
-- *23* New experiments relevant to the current *Coronavirus (COVID-19)* outbreak research.
+- *23* experiments relevant to the research of the current *COVID-19* outbreak caused by the *coronavirus SARS-Cov-2*.
   - [Transcriptional response of human lung epithelial cells to SARS-CoV-2 infection.](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-147507)
   - [Transcription profiling by array of human bronchial epithelial cells after infection with SARS-CoV and DOHV](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-17400)
   - [SHAE004: SARS-CoV, SARS-dORF6 and SARS-BatSRBD infection of HAE cultures.](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-47962)
@@ -63,5 +63,4 @@
   - [Grapevine field experiments reveal the contribution of genotype, the influence of environment and the effect of their interaction (G3E) on the berry transcriptome [RNA-seq]](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-97960)
   - [mRNA-Seq of head tissue from Drosophila melanogaster](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-57337)
   - [Transcription profiling by high throughput sequencing of maize B73, Mo17 and the SX19 inbred mapping population](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-97960)
-
 

--- a/release-notes/gxa/_posts/2020-05-05-35.md
+++ b/release-notes/gxa/_posts/2020-05-05-35.md
@@ -1,0 +1,50 @@
+#### Data statistics
+
+- Ensembl **99** / Ensembl Genomes **46** / WormBase ParaSite **14** gene annotations and
+  array design probe set mappings.   
+- This release contains **3,942** datasets (**131,311** assays), in particular:            
+  - **1,091** RNA-seq and **25** proteomics datasets, of which **214** report
+    [baseline](https://www.ebi.ac.uk/gxa/baseline/experiments) gene expression, across a total of **44** different
+    organisms;           
+  - **923** datasets reporting expression in [plants](https://www.ebi.ac.uk/gxa/plant/experiments);               
+  - **3,728** datasets studying samples in **11,205**
+    [differential](https://www.ebi.ac.uk/gxa/help/index.html#differential-expression) comparisons across **50**
+    different organisms.
+  - **65** overall species count
+
+
+#### New experiments
+
+- New Coronavirus disease (COVID) experiments
+  - [Transcriptional response of human lung epithelial cells to SARS-CoV-2 infection.](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-147507)
+  - [Host responses contributing to the attenuation of severe acute respiratory syndrome coronaviruses missing E protein domains](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-59185)
+  - [SARS infection of C57BL6, TIMP1 and Serpine1 knock-out mice](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-51386)
+  - [Human airway epithelial responses to rhinovirus infection and cigarette smoke extract alone and in combination](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-27973)
+  - [Infection of wild type and CXCR3 knockout C57BL6/J mice with SARS MA15](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-50878)
+
+- New Differential experiments      
+  - [Transcriptome analysis of the effect of the hsl2 mutation in root tips](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-116517)
+  - [TMK1-mediated transcriptional auxin signaling guides differential growth in Arabidopsis thaliana](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-111716)
+  - [BLISTER safeguards the protein kinase activity of ER stress modulator IRE1A during plant growth and development in Arabidopsis thaliana](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-124235)
+  - [Plant development on ISS differs from the development on the ground and is influenced by the genetic background](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-95373)
+  - [RNA-seq of 21 sessile serrated colon adenoma/polyps, 10 hyperplastic polyps, 10 adenomas, 21 uninvolved colon and 20 control colon specimens](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-76987)
+  - [mRNA and small RNA associated with Crohn's disease behavior [RNA-Seq]](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-66207)
+  - [Whole transcriptome sequencing of Treg with and without Mef2d, Mef2c, HDAC1, HDAC2 or Dyrk1 deletion](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-139480)
+  - [RNA-seq and DNA methylomes of germinating rice and developing coleoptiles (RNA-Seq)](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-115371)
+  - [RNA-seq of leaf, root, and stem xylem from Western poplar (Populus trichocarpa) plants in response to drought, high salinity, heat and cold stress](https://www.ebi.ac.uk/gxa/experiments/E-MTAB-5540)
+  - [RNA-seq sequencing to investigate the effect of ZmDWF4 on Zea mays seed development](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-108628)
+
+- New Baseline experiments      
+  - [BLUEPRINT EpiVar project: Genetic Drivers of Epigenetic and Transcriptional Variation in Human Immune Cells](https://www.ebi.ac.uk/gxa/experiments/E-ENAD-34)
+  - [RNA-seq of human islet pancreatic cells to identify eQTL loci](https://www.ebi.ac.uk/gxa/experiments/E-ENAD-42)
+  - [HipSci Project - RNAseq of healthy volunteers](https://www.ebi.ac.uk/gxa/experiments/E-ENAD-35)
+  - [Regulation of gene expression in macrophage immune response](https://www.ebi.ac.uk/gxa/experiments/E-ENAD-41)
+  - [Transcription profiling by high throughput sequencing of two Arabidopsis F6 hybrid mimic lines compared with either C24 or Ler parental lines](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-64742)
+  - [Zygotic Genome Activation Occurs Shortly After Fertilization in Zea mays](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-98379)
+  - [Characterization of imprinted genes in rice reveals regulation and imprinting conservation at some loci in plant species](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-113769)
+  - [Grapevine field experiments reveal the contribution of genotype, the influence of environment and the effect of their interaction (G3E) on the berry transcriptome [RNA-seq]](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-97960)
+  - [mRNA-Seq of head tissue from Drosophila melanogaster](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-57337)
+  - [Transcription profiling by high throughput sequencing of maize B73, Mo17 and the SX19 inbred mapping population](https://www.ebi.ac.uk/gxa/experiments/E-GEOD-97960)
+
+
+


### PR DESCRIPTION
In this PR,
- GXA data statistics and release notes including bulk and microarray studies.
- New Covid studies are highlighted.

Note: Although in this release we didn't add any new species explicitly the overall count and species in baseline and differential are up as the web API has stratified studies and sub species. 