### PR TITLE
Patch cell stats after old missing study

### DIFF
--- a/release-notes/sc/_posts/2020-05-14-10.md
+++ b/release-notes/sc/_posts/2020-05-14-10.md
@@ -1,6 +1,6 @@
 #### Data statistics
 - Ensembl **99** / Ensembl Genomes **46** / WormBase ParaSite **14** gene annotations.   
-- This release contains **164** single cell RNA-Seq studies, consisting of **4,646,599** cells, of which **3,342,629** passed our QC from **14** different species.
+- This release contains **165** single cell RNA-Seq studies, consisting of **4,657,221** cells, of which **3,349,208** passed our QC from **14** different species.
 - No new species, the aim of this release was to focus on COVID-19 related datasets and to use the new version [0.2.0](https://github.com/ebi-gene-expression-group/scxa-workflows/tree/0.2.0) of our analysis pipeline:
   - Alevin updated to 1.2
   - Scanpy updated to 1.4.3, and tertiary workflow remodelled. As a result, many tSNE plots improved notably.


### PR DESCRIPTION
We found that an older study hasn't been reloaded and was in a faulty state. This patch of the release notes reflect that.