### PR TITLE
Makes the gxa helper equivalent to the SC one

### DIFF
--- a/gxa_helper/bin/gxa_release_data_stats.sh
+++ b/gxa_helper/bin/gxa_release_data_stats.sh
@@ -90,13 +90,13 @@ echo -e "\n\n\n#### New experiments" >> $releaseNotesFile
 echo -e "\n- New Differential experiments" >> $releaseNotesFile
 ## parse list of new differential studies to get write experiment titles
 curl 'https://wwwdev.ebi.ac.uk/gxa/json/experiments' | \
-    jq -r '.experiments | .[] | select(.loadDate | strptime("%d-%m-%Y") | mktime > '$last_release_epoch_time') | select(.experimentType == "Differential" ) | [.experimentAccession, .experimentDescription] | @csv' | \
+    jq -r '.experiments | .[] | select(.loadDate | strptime("%d-%m-%Y") | mktime > '$last_release_epoch_time') | select(.rawExperimentType | test("DIFFERENTIAL"; "i")) | [.experimentAccession, .experimentDescription] | @csv' | \
     awk -v FS="," '{ printf "- [%s](https://www.ebi.ac.uk/gxa/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
 
 echo -e "\n- New Baseline experiments" >> $releaseNotesFile
 ## parse list of new differential studies to get write experiment titles
 curl 'https://wwwdev.ebi.ac.uk/gxa/json/experiments' | \
-    jq -r '.experiments | .[] | select(.loadDate | strptime("%d-%m-%Y") | mktime > '$last_release_epoch_time') | select(.experimentType == "Baseline" ) | [.experimentAccession, .experimentDescription] | @csv' | \
+    jq -r '.experiments | .[] | select(.loadDate | strptime("%d-%m-%Y") | mktime > '$last_release_epoch_time') | select(.rawExperimentType | test("BASELINE"; "i")) | [.experimentAccession, .experimentDescription] | @csv' | \
     awk -v FS="," '{ printf "- [%s](https://www.ebi.ac.uk/gxa/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
 
 


### PR DESCRIPTION
This PR makes the GXA helper equivalent to the SC one:

- Lists all new experiments, so that curators can pick the highlights.
- Avoids any difficult to get input.