### PR TITLE
Fix parsing of experiment IDs and names

### DIFF
--- a/gxa_helper/bin/gxa_release_data_stats.sh
+++ b/gxa_helper/bin/gxa_release_data_stats.sh
@@ -90,7 +90,8 @@ echo -e "\n\n\n#### Selected new experiments" >> $releaseNotesFile
 echo -e "\n#### Selected differential experiments\n" >> $releaseNotesFile
 ## parse list of new differential studies to get write experiment titles
 curl 'https://wwwdev.ebi.ac.uk/gxa/json/experiments' | \
-    jq -r '.experiments | .[] | select(.loadDate | strptime("%d-%m-%Y") | mktime > '$last_release_epoch_time') | select(.rawExperimentType | test("DIFFERENTIAL"; "i")) | [.experimentAccession, .experimentDescription] | @csv' | \
+    jq -r '.experiments | .[] | select(.loadDate | strptime("%d-%m-%Y") | mktime > '$last_release_epoch_time') | select(.rawExperimentType | test("DIFFERENTIAL"; "i")) | [.experimentAccession, .experimentDescription] | @tsv' | \
+    awk -F'\t' '{ printf "- [%s](https://www.ebi.ac.uk/gxa/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
     awk -v FPAT="^([^,]+)|(\"[^\"]+\")$" '{ printf "- [%s](https://www.ebi.ac.uk/gxa/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
 
 echo -e "\n#### Selected baseline experiments\n" >> $releaseNotesFile

--- a/gxa_helper/bin/gxa_release_data_stats.sh
+++ b/gxa_helper/bin/gxa_release_data_stats.sh
@@ -92,7 +92,6 @@ echo -e "\n#### Selected differential experiments\n" >> $releaseNotesFile
 curl 'https://wwwdev.ebi.ac.uk/gxa/json/experiments' | \
     jq -r '.experiments | .[] | select(.loadDate | strptime("%d-%m-%Y") | mktime > '$last_release_epoch_time') | select(.rawExperimentType | test("DIFFERENTIAL"; "i")) | [.experimentAccession, .experimentDescription] | @tsv' | \
     awk -F'\t' '{ printf "- [%s](https://www.ebi.ac.uk/gxa/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
-    awk -v FPAT="^([^,]+)|(\"[^\"]+\")$" '{ printf "- [%s](https://www.ebi.ac.uk/gxa/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
 
 echo -e "\n#### Selected baseline experiments\n" >> $releaseNotesFile
 ## parse list of new differential studies to get write experiment titles

--- a/gxa_helper/bin/gxa_release_data_stats.sh
+++ b/gxa_helper/bin/gxa_release_data_stats.sh
@@ -91,7 +91,7 @@ echo -e "\n#### Selected differential experiments\n" >> $releaseNotesFile
 ## parse list of new differential studies to get write experiment titles
 curl 'https://wwwdev.ebi.ac.uk/gxa/json/experiments' | \
     jq -r '.experiments | .[] | select(.loadDate | strptime("%d-%m-%Y") | mktime > '$last_release_epoch_time') | select(.rawExperimentType | test("DIFFERENTIAL"; "i")) | [.experimentAccession, .experimentDescription] | @csv' | \
-    awk -v FS="," '{ printf "- [%s](https://www.ebi.ac.uk/gxa/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
+    awk -v FPAT="^([^,]+)|(\"[^\"]+\")$" '{ printf "- [%s](https://www.ebi.ac.uk/gxa/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
 
 echo -e "\n#### Selected baseline experiments\n" >> $releaseNotesFile
 ## parse list of new differential studies to get write experiment titles

--- a/sc_helper/bin/start_new_release_notes.sh
+++ b/sc_helper/bin/start_new_release_notes.sh
@@ -71,8 +71,8 @@ cat sc_helper/release_notes_templates/data_statistics.md | \
 echo -e "\n#### New experiments" >> $releaseNotesFile
 
 curl 'https://wwwdev.ebi.ac.uk/gxa/sc/json/experiments' | 
-    jq -r '.experiments | .[] | select(.lastUpdate | strptime("%d-%m-%Y") | mktime > '$last_release_epoch_time') | [.experimentAccession, .experimentDescription] | @csv' | \
-    awk -v FPAT="^([^,]+)|(\"[^\"]+\")$" '{ printf "- [%s](https://www.ebi.ac.uk/gxa/sc/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
+    jq -r '.experiments | .[] | select(.lastUpdate | strptime("%d-%m-%Y") | mktime > '$last_release_epoch_time') | [.experimentAccession, .experimentDescription] | @tsv' | \
+    awk -F'\t' '{ printf "- [%s](https://www.ebi.ac.uk/gxa/sc/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
 
 echo -e "\n#### New features" >> $releaseNotesFile
 

--- a/sc_helper/bin/start_new_release_notes.sh
+++ b/sc_helper/bin/start_new_release_notes.sh
@@ -72,7 +72,7 @@ echo -e "\n#### New experiments" >> $releaseNotesFile
 
 curl 'https://wwwdev.ebi.ac.uk/gxa/sc/json/experiments' | 
     jq -r '.experiments | .[] | select(.lastUpdate | strptime("%d-%m-%Y") | mktime > '$last_release_epoch_time') | [.experimentAccession, .experimentDescription] | @csv' | \
-    awk -v FS="," '{ printf "- [%s](https://www.ebi.ac.uk/gxa/sc/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
+    awk -v FPAT="^([^,]+)|(\"[^\"]+\")$" '{ printf "- [%s](https://www.ebi.ac.uk/gxa/sc/experiments/%s)\n", $2, $1}' | sed s/\"//g >> $releaseNotesFile
 
 echo -e "\n#### New features" >> $releaseNotesFile
 


### PR DESCRIPTION
The previous parser uses `,` as a field separator, which does not behave as planned when an experiment name string uses a comma, as reported [here](https://github.com/ebi-gene-expression-group/atlas-release-notes/issues/37). This fix replaces the field separator with a regular expresion for the desired field patterns.  It also only accepts `,` when inside the second/last element (the experiment name) of the parsed string.

This, as far as tested, works using `gawk` (the default awk in codon as fg_atlas or fg_atlas_sc), but not in other awk versions, like `mawk` or the original `awk`. 